### PR TITLE
Interactive functionality not working for SVG images.

### DIFF
--- a/example/index.md
+++ b/example/index.md
@@ -441,3 +441,43 @@ identity provider: Indentity Provider {
 }
 ```
 ````
+
+## Interactive Tooltips
+
+```d2
+x: {tooltip: Total abstinence is easier than perfect moderation}
+y: {tooltip: Gee, I feel kind of LIGHT in the head now,\nknowing I can't make my satellite dish PAYMENTS!}
+x -> y
+```
+
+````
+```d2
+x: {tooltip: Total abstinence is easier than perfect moderation}
+y: {tooltip: Gee, I feel kind of LIGHT in the head now,\nknowing I can't make my satellite dish PAYMENTS!}
+x -> y
+```
+````
+
+## Interactive Links
+
+```d2
+x: I'm a Mac {
+  link: https://apple.com
+}
+y: And I'm a PC {
+  link: https://microsoft.com
+}
+x -> y: gazoontite
+```
+
+````
+```d2
+x: I'm a Mac {
+  link: https://apple.com
+}
+y: And I'm a PC {
+  link: https://microsoft.com
+}
+x -> y: gazoontite
+```
+````

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vitepress-plugin-d2",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vitepress-plugin-d2",
-      "version": "1.0.0",
+      "version": "1.0.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.11.25",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vitepress-plugin-d2",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Plugin for VitePress to add support for rendering D2 diagrams.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
- Fixed issue with SVG being rendered as image, not HTML element, causing interactive functionality to not work.
- Added interactive functionality examples to example deployment.

Related Bug: https://github.com/BadgerHobbs/vitepress-plugin-d2/issues/1